### PR TITLE
fix: typos and spell-fix in architecture, customisations and plugins section of docs

### DIFF
--- a/pages/docs/architecture/index.md
+++ b/pages/docs/architecture/index.md
@@ -17,7 +17,7 @@ entirely of their props. For more discussion on this mindset [read this post by 
 ![Component Architecture](componentArchitecture.png)
 
 The components are deeply nested but only a minimal amount of props are passed from the top down. Most of the data is obtained through
-the container components connection to the Redux store and passed to the view components as props.
+the container components' connection to the Redux store and passed to the view components as props.
 
 ### reducers ###
 Reducers in Griddle are methods that work against an immutable state object. A standard reducer method should look like:
@@ -89,6 +89,6 @@ individual selectors to obtain the data that they need.
 ## Pluggable Architecture ##
 
 This architecture allows overriding any part of this system while keeping everything else intact. For example, a plugin could
-have a series of its own container components and selectors and the view components and reducers would work with out any modification.
+have a series of its own container components and selectors and the view components and reducers would work without any modification.
 In fact, this is exactly what we are doing with Griddle for the local data plugin (the plugin that says you want to maintain all your
 data locally in the browser). [See more about this in the plugins section](../plugins)

--- a/pages/docs/customization/index.jsx
+++ b/pages/docs/customization/index.jsx
@@ -43,7 +43,7 @@ const componentCustomization = `
   ## Component Customization ##
 
   Griddle exists as a series of container and view components. Container components are specifically responsible for getting data from
-  griddle's store, where as view components are responsible for displaying data ([see architecture](../architecture/) for more on this).
+  griddle's store, whereas view components are responsible for displaying data ([see architecture](../architecture/) for more on this).
   If we wanted to change the Filter component to be a dropdown to look for only a couple of specified option we could do so through the
   customizing Griddle's components.
 

--- a/pages/docs/plugins/index.md
+++ b/pages/docs/plugins/index.md
@@ -70,7 +70,7 @@ See the Position plugin's `TableEnhancer` to see how this is used in a real situ
 
 More often than not, most new components don't need to be added to your plugin's `components` object as they will be imported where they're needed in components that *do* overwrite existing components.
 
-If you do want the expose the ability for other plugins to overwrite / enhance new components you create, simply add them to the `component` property with a distinct name.
+If you do want to expose the ability for other plugins to overwrite / enhance new components you create, simply add them to the `component` property with a distinct name.
 
 ```
 ...
@@ -82,11 +82,11 @@ components: {
 
 ## reducer `Object`
 
-When adding functionality to Griddle, you'll likely need to response to actions and update the application state. This can easily be done by adding action handling functions to your `reducer` object.
+When adding functionality to Griddle, you'll likely need to respond to actions and update the application state. This can easily be done by adding action handling functions to your `reducer` object.
 
 Griddle uses [Redux](http://redux.js.org/) as well as [ImmutableJS](https://facebook.github.io/immutable-js/), so being familiar with these technologies will make things easier.
 
-Additionally, the entirety of Griddles state can be accessed an modified from a Plugin's reducer.
+Additionally, the entirety of Griddles state can be accessed and modified from a Plugin's reducer.
 
 #### Handling an action
 
@@ -119,7 +119,7 @@ If your plugin needs to keep track of additional application state, you'll want 
 
 This object will be merged with the all Griddle and other Plugin's state via `Object.assign`, so you'll want to make sure that state properties are unique to avoid conflicts with other plugins.
 
-Once merged, value will then be converted into an ImmutableJS Map and accessed in your `reducers` and `selectors`.
+Once merged, values will then be converted into an ImmutableJS Map and accessed in your `reducers` and `selectors`.
 
 Example initial state:
 ```


### PR DESCRIPTION
fix: typos and spellings to architecture and plugins index.md

fix: typo spell-fix to customization docs